### PR TITLE
Materialize stateful rules for algorithm fallback

### DIFF
--- a/src/beekeeper/flow/beekeeper.py
+++ b/src/beekeeper/flow/beekeeper.py
@@ -98,7 +98,7 @@ class BeeKeeper[TEntity: AnyEntity, TAllocationRequest: AnyRequest]:
             ]
 
         self._preliminary_rules = preliminary_rules
-        self._stateful_rules = stateful_rules
+        self._stateful_rules = tuple(stateful_rules)
         self._input_adapter = input_adapter
         self._stages: Sequence[BaseBeeKeeperFlowStage[TEntity, TAllocationRequest]] = stages
 

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -21,6 +21,7 @@ from beekeeper import (
     Entity,
     EntityInputAdapter,
     HardPreliminaryRule,
+    HardStatefulRule,
     InputAdapter,
     OutputAdapter,
     SoftPreliminaryRule,
@@ -383,6 +384,19 @@ class _AlwaysFails(LoadBalancingAssignmentAlgorithm[_Worker, _Request]):
         raise IncompleteSolutionError("test double — always fails")
 
 
+class _ConsumesRulesThenFails(_AlwaysFails):
+    """Test double: exhaust rules before reporting failure."""
+
+    def run(self, allocations, entities, candidates, rules):  # type: ignore[no-untyped-def]
+        list(rules)
+        return super().run(allocations, entities, candidates, rules)
+
+
+class _RejectAllStatefulRule(HardStatefulRule[_Worker, _Request]):
+    def check(self, entity, allocation, state):  # type: ignore[no-untyped-def]
+        return False
+
+
 class TestAlgorithmChain:
     def test_single_algorithm_works_unchanged(self) -> None:
         """Passing a bare algorithm (not a list) is the common path."""
@@ -416,6 +430,25 @@ class TestAlgorithmChain:
 
         assert sink.captured is not None
         assert len(sink.captured.assignments) == 1
+
+    def test_stateful_rules_generator_survives_algorithm_fallback(self) -> None:
+        """A fallback algorithm still sees stateful rules after a failed head algorithm."""
+        worker = _Worker(name="W", unavailabilities=[])
+        allocation = _request(1, 2)
+        sink = _CapturingOutput()
+
+        BeeKeeper[_Worker, _Request](
+            input_adapter=_adapter([worker], [allocation]),
+            algorithm=[
+                _ConsumesRulesThenFails(),
+                LoadBalancingAssignmentAlgorithm[_Worker, _Request](),
+            ],
+            stateful_rules=(rule for rule in [_RejectAllStatefulRule()]),
+            output_adapters=[sink],
+        ).execute()
+
+        assert sink.captured is not None
+        assert sink.captured.assignments == []
 
     def test_chain_stops_at_first_success(self) -> None:
         """Load-balancing at the head succeeds; the trailing entries never run."""


### PR DESCRIPTION
## Summary
- materialize `stateful_rules` into a tuple when constructing `BeeKeeper`
- add a regression test for generator-backed stateful rules across algorithm fallback

## Root cause
`stateful_rules` accepted any `Iterable`, so a generator could be consumed by the first algorithm in a chain. If that algorithm raised `IncompleteSolutionError`, the fallback algorithm received the same exhausted generator and skipped stateful constraints.

Fixes #24.

## Checks
- `uv run pytest tests/test_pipeline_integration.py -q`
- `uv run ruff check src/beekeeper/flow/beekeeper.py tests/test_pipeline_integration.py`
- `uv run mypy src`
- `uv run pytest -q`