### PR TITLE
docs: correct RuleVerdict docstring on 0.0 score behavior

### DIFF
--- a/src/beekeeper/rules/rule_verdict.py
+++ b/src/beekeeper/rules/rule_verdict.py
@@ -14,8 +14,11 @@ class RuleVerdict:
     * **score**: how *well* does the entity satisfy this rule, on an arbitrary
       non-negative finite scale? Higher is better. A ``score`` of ``1.0``
       means the rule is fully satisfied without preference; lower scores
-      express soft preference; ``0.0`` is treated as a drop (the geometric-
-      mean aggregator collapses to zero, pruning the candidate). The
+      express soft preference. A ``score`` of ``0.0`` collapses the
+      geometric-mean aggregate to zero, ranking the candidate last, but does
+      *not* exclude it: a zero-scored candidate is still recorded and remains
+      assignable when no better candidate exists. To exclude a candidate
+      outright, return ``compatible=False`` rather than a zero score. The
       framework aggregates scores across rules using the geometric mean —
       see ``docs/explanations/soft-rules-aggregation.md``.
 


### PR DESCRIPTION
Closes #13

Corrects the RuleVerdict docstring, which wrongly claimed a soft score of 0.0
"prunes the candidate." A zero-scored candidate actually survives with score 0.0
and stays assignable (e.g. when it's the only candidate), as candidate.py and
docs/explanations/soft-rules-aggregation.md already describe.

Reworded so the docstring now states that 0.0 collapses the geometric-mean
aggregate to zero and ranks the candidate last, but does not exclude it, and
that hard exclusion is expressed via compatible=False.

Docstring-only change. Full test suite passes unchanged (135 passed, 18 skipped).