### PR TITLE
Fill allocations whose required_count exceeds the backtracking top-K cap

### DIFF
--- a/src/beekeeper/algorithm/implementations/backtracking.py
+++ b/src/beekeeper/algorithm/implementations/backtracking.py
@@ -37,13 +37,15 @@ class BacktrackingAssignmentAlgorithm[
 
     Three guards keep the worst-case search tractable:
 
-    * **Feasibility filter.** Allocations whose candidate pool is smaller than
-      their ``required_count`` are unfulfillable by definition and are skipped
-      before the search starts. Letting them through would cause the search
-      to exhaustively try every combination of every *earlier* allocation
-      before giving up.
-    * **Top-K candidate cap.** Only the ``top_k_candidates`` highest-scored
-      candidates per allocation enter the search. Default 30.
+    * **Feasibility filter.** Allocations whose eligible candidate pool is
+      smaller than their ``required_count`` are unfulfillable by definition
+      and are skipped before the search starts. Letting them through would
+      cause the search to exhaustively try every combination of every
+      *earlier* allocation before giving up.
+    * **Top-K candidate cap.** Only the highest-scored candidates per
+      allocation enter the search: ``top_k_candidates`` of them, or
+      ``required_count`` when that is larger, so the count-based feasibility
+      filter is never tripped by the cap alone. Default 30.
     * **Iteration cap.** A hard ``max_iterations`` budget on recursive calls
       so even pathological inputs don't run forever.
 
@@ -96,7 +98,7 @@ class BacktrackingAssignmentAlgorithm[
             id(alloc): [
                 c.entity
                 for c in sorted(candidates.get(id(alloc), []), key=lambda c: c.score, reverse=True)[
-                    : self._top_k_candidates
+                    : max(self._top_k_candidates, alloc.required_count)
                 ]
             ]
             for alloc in allocations

--- a/tests/test_backtracking.py
+++ b/tests/test_backtracking.py
@@ -14,6 +14,7 @@ from beekeeper import (
 )
 from beekeeper.algorithm.errors import IncompleteSolutionError
 from beekeeper.algorithm.implementations.backtracking import BacktrackingAssignmentAlgorithm
+from beekeeper.algorithm.implementations.load_balancing import LoadBalancingAssignmentAlgorithm
 from beekeeper.flow.candidate import Candidate
 
 
@@ -193,3 +194,49 @@ class TestBacktrackingTopKCap:
         assigned = result.assignments[0].assigned_entities
         assert len(assigned) == 1
         assert assigned[0] in workers[:cap]
+
+    def test_fills_allocation_when_required_count_exceeds_top_k(self) -> None:
+        """An allocation whose required_count exceeds the cap is still filled."""
+        workers = [_Worker(name=f"W{i}", unavailabilities=[]) for i in range(5)]
+        allocation = _request(1, 2, required_count=4)
+        candidates_list = [Candidate(entity=w, score=1.0 - i / 100) for i, w in enumerate(workers)]
+        # The cap (3) is below required_count (4). Measuring feasibility against
+        # the truncated pool used to drop this allocation even though five
+        # genuine candidates can fill it.
+        algo = BacktrackingAssignmentAlgorithm[_Worker, _Request](top_k_candidates=3)
+
+        result = algo.run(
+            allocations=[allocation],
+            entities=workers,
+            candidates={id(allocation): candidates_list},
+            rules=[],
+        )
+
+        assert len(result.assignments) == 1
+        assigned = result.assignments[0].assigned_entities
+        assert len(assigned) == 4
+        # The cap widens only as far as required_count, so the four
+        # highest-scored candidates fill the slot and the lowest-scored stays out.
+        assert {w.name for w in assigned} == {w.name for w in workers[:4]}
+
+    def test_agrees_with_load_balancing_when_pool_exceeds_cap(self) -> None:
+        """Backtracking and load balancing agree on feasibility above the cap."""
+        workers = [_Worker(name=f"W{i}", unavailabilities=[]) for i in range(5)]
+        allocation = _request(1, 2, required_count=4)
+        candidates_list = [Candidate(entity=w, score=1.0 - i / 100) for i, w in enumerate(workers)]
+        candidate_map = {id(allocation): candidates_list}
+
+        backtracking = BacktrackingAssignmentAlgorithm[_Worker, _Request](top_k_candidates=3).run(
+            allocations=[allocation],
+            entities=workers,
+            candidates=candidate_map,
+            rules=[],
+        )
+        load_balancing = LoadBalancingAssignmentAlgorithm[_Worker, _Request]().run(
+            allocations=[allocation],
+            entities=workers,
+            candidates=candidate_map,
+            rules=[],
+        )
+
+        assert len(backtracking.assignments) == len(load_balancing.assignments) == 1


### PR DESCRIPTION
## Summary
- rank `max(top_k_candidates, required_count)` candidates per allocation in `_rank_candidates`, so an allocation that needs more entities than the cap is still filled when its eligible pool is large enough
- correct the `BacktrackingAssignmentAlgorithm` docstring (the "Feasibility filter" and "Top-K candidate cap" bullets)
- add two regression tests for `required_count > top_k_candidates` (the existing `TestBacktrackingTopKCap` only covered `required_count=1`)

## Root cause
`_rank_candidates` truncates each allocation's pool to `top_k_candidates`. The feasibility filter in `run` then measures that already-truncated map:

```python
feasible = [a for a in allocations_list if len(ranked[id(a)]) >= a.required_count]
```

so an allocation needing more than `top_k_candidates` entities is judged infeasible and skipped. The search reads the same truncated map (`combinations(ranked[id(allocation)], required_count)`), so the cap, not the real pool size, decides the outcome. `required_count` has no upper bound (`Field(default=1, ge=1)`), and `LoadBalancingAssignmentAlgorithm` and `OrToolsAssignmentAlgorithm` both fill the same allocation, so this is an inconsistency rather than a deliberate limit.

Fixing only the feasibility check is not enough: the search draws from the same ranked map, so the allocation would pass the filter and then raise `IncompleteSolutionError` because `combinations` over the still-truncated pool yields nothing. Ranking `max(top_k_candidates, required_count)` keeps both sites consistent, and leaves behavior unchanged when `required_count <= top_k_candidates`.

Fixes #12.

## Checks
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run mypy src`
- `uv run coverage run -m pytest` (137 passed, 100% line and branch)
- `uv run pytest --benchmark-only` (18 passed)
- `uv run mkdocs build --strict`
