### PR TITLE
docs: swap docs URL from xiddoc.github.io to iliketo.party/BeeKeeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://github.com/Xiddoc/BeeKeeper/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/Xiddoc/BeeKeeper/ci.yml?branch=master&style=for-the-badge&logo=githubactions&label=CI" alt="CI"></a>
   <a href="https://github.com/Xiddoc/BeeKeeper/actions/workflows/ci.yml"><img src="https://img.shields.io/badge/coverage-100%25-brightgreen?style=for-the-badge&logo=pytest&logoColor=white" alt="Coverage 100%"></a>
   <img src="https://img.shields.io/badge/python-3.13+-blue?style=for-the-badge&logo=python" alt="Python 3.13+">
-  <a href="https://xiddoc.github.io/BeeKeeper/"><img src="https://img.shields.io/badge/docs-mkdocs--material-blue?style=for-the-badge&logo=materialformkdocs&logoColor=white" alt="Docs"></a>
+  <a href="https://iliketo.party/BeeKeeper/"><img src="https://img.shields.io/badge/docs-mkdocs--material-blue?style=for-the-badge&logo=materialformkdocs&logoColor=white" alt="Docs"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPL3.0-green?style=for-the-badge" alt="License: GPL3.0"></a>
 </p>
 
@@ -26,7 +26,7 @@ For the OR-Tools-backed assignment algorithm, add the optional extra:
 uv sync --extra ortools
 ```
 
-See [Optional extras](https://xiddoc.github.io/BeeKeeper/#optional-extras) in the docs for the full set of install paths.
+See [Optional extras](https://iliketo.party/BeeKeeper/#optional-extras) in the docs for the full set of install paths.
 
 ## 30-line quickstart
 
@@ -65,7 +65,7 @@ A complete worked example lives at [`examples/mcdonalds/`](examples/mcdonalds), 
 
 ## Documentation
 
-Full docs at **[xiddoc.github.io/BeeKeeper](https://xiddoc.github.io/BeeKeeper/)** — concepts, how-to recipes, the McDonald's walkthrough, and an auto-generated API reference.
+Full docs at **[iliketo.party/BeeKeeper](https://iliketo.party/BeeKeeper/)** — concepts, how-to recipes, the McDonald's walkthrough, and an auto-generated API reference.
 
 Or build locally:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: BeeKeeper
 site_description: Manage the Bee-sy with ease — a Python framework for assigning entities to allocation requests.
-site_url: https://xiddoc.github.io/BeeKeeper/
+site_url: https://iliketo.party/BeeKeeper/
 repo_url: https://github.com/Xiddoc/BeeKeeper
 repo_name: Xiddoc/BeeKeeper
 edit_uri: edit/master/docs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ ortools = ["ortools>=9.10"]
 
 [project.urls]
 Homepage = "https://github.com/Xiddoc/BeeKeeper"
-Documentation = "https://xiddoc.github.io/BeeKeeper/"
+Documentation = "https://iliketo.party/BeeKeeper/"
 Repository = "https://github.com/Xiddoc/BeeKeeper"
 Issues = "https://github.com/Xiddoc/BeeKeeper/issues"
 


### PR DESCRIPTION
## 📖 Summary

Swapped all documentation URLs from the old GitHub Pages domain to the custom domain, as requested in #10.

### 🔄 Changes

| File | Change |
|---|---|
| `mkdocs.yml` | `site_url` → `https://iliketo.party/BeeKeeper/` |
| `pyproject.toml` | `Documentation` link → `https://iliketo.party/BeeKeeper/` |
| `README.md` | 3 links: badge, optional extras, and docs section |

### 📋 Related Issue

Closes #10

### 🏷️ Type of change

- [x] 📝 Documentation update
- [ ] ✨ New feature
- [ ] 🐛 Bug fix

### ✅ Checklist

- [x] All 5 occurrences of old URL replaced
- [x] Links point to canonical custom domain
- [x] No code changes