### PR TITLE
fix: include source file path in JSON adapter validation errors

### DIFF
--- a/src/beekeeper/adapters/inputs/json_allocation_input_adapter.py
+++ b/src/beekeeper/adapters/inputs/json_allocation_input_adapter.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 
 from beekeeper.adapters.inputs.allocation_input_adapter import AllocationInputAdapter
 from beekeeper.allocations.allocation_request import AnyRequest
@@ -33,4 +33,7 @@ class JsonAllocationInputAdapter[TAllocationRequest: AnyRequest](
 
     def get_allocations(self) -> Iterable[TAllocationRequest]:
         adapter: TypeAdapter[list[TAllocationRequest]] = TypeAdapter(list[self.allocation_type])  # type: ignore[name-defined]
-        return adapter.validate_json(self.file.read_text())
+        try:
+            return adapter.validate_json(self.file.read_text())
+        except ValidationError as exc:
+            raise ValueError(f"Failed to parse {self.file}: {exc}") from exc

--- a/src/beekeeper/adapters/inputs/json_entity_input_adapter.py
+++ b/src/beekeeper/adapters/inputs/json_entity_input_adapter.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 
 from beekeeper.adapters.inputs.entity_input_adapter import EntityInputAdapter
 from beekeeper.entities.entity import AnyEntity
@@ -30,4 +30,7 @@ class JsonEntityInputAdapter[TEntity: AnyEntity](EntityInputAdapter[TEntity]):
 
     def get_entities(self) -> Iterable[TEntity]:
         adapter: TypeAdapter[list[TEntity]] = TypeAdapter(list[self.entity_type])  # type: ignore[name-defined]
-        return adapter.validate_json(self.file.read_text())
+        try:
+            return adapter.validate_json(self.file.read_text())
+        except ValidationError as exc:
+            raise ValueError(f"Failed to parse {self.file}: {exc}") from exc

--- a/tests/test_json_input_adapters.py
+++ b/tests/test_json_input_adapters.py
@@ -1,0 +1,92 @@
+"""
+Tests for the JSON-backed input adapters.
+
+Both ``JsonEntityInputAdapter`` and ``JsonAllocationInputAdapter`` wrap
+``pydantic.ValidationError`` in a ``ValueError`` that names the source
+file, so a validation failure in a multi-file setup (e.g. via
+``CompositeInputAdapter``) can be traced back to the offending file.
+"""
+import re
+from enum import auto
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from beekeeper import AllocationRequest, AllocationType, Entity, Unavailability
+from beekeeper.adapters.inputs.json_allocation_input_adapter import (
+    JsonAllocationInputAdapter,
+)
+from beekeeper.adapters.inputs.json_entity_input_adapter import JsonEntityInputAdapter
+
+
+class _Task(AllocationType):
+    SHIFT = auto()
+
+
+class _Worker(Entity[Unavailability]):
+    name: str
+
+
+class _Request(AllocationRequest[_Task, _Worker]):
+    pass
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    file = tmp_path / name
+    file.write_text(content)
+    return file
+
+
+def test_entity_adapter_malformed_json_names_file(tmp_path: Path) -> None:
+    file = _write(tmp_path, "workers.json", "{not valid json")
+    adapter = JsonEntityInputAdapter(file=file, entity_type=_Worker)
+
+    with pytest.raises(ValueError, match=re.escape("workers.json")) as exc_info:
+        list(adapter.get_entities())
+
+    assert isinstance(exc_info.value.__cause__, ValidationError)
+
+
+def test_entity_adapter_extra_field_names_file(tmp_path: Path) -> None:
+    file = _write(tmp_path, "workers.json", '[{"name": "Alice", "totally_unknown_field": 1}]')
+    adapter = JsonEntityInputAdapter(file=file, entity_type=_Worker)
+
+    with pytest.raises(ValueError, match=re.escape("workers.json")) as exc_info:
+        list(adapter.get_entities())
+
+    assert isinstance(exc_info.value.__cause__, ValidationError)
+
+
+def test_entity_adapter_valid_file_unchanged(tmp_path: Path) -> None:
+    file = _write(tmp_path, "workers.json", '[{"name": "Alice", "unavailabilities": []}]')
+    adapter = JsonEntityInputAdapter(file=file, entity_type=_Worker)
+
+    entities = list(adapter.get_entities())
+
+    assert len(entities) == 1
+    assert entities[0].name == "Alice"
+
+
+def test_allocation_adapter_malformed_json_names_file(tmp_path: Path) -> None:
+    file = _write(tmp_path, "allocations.json", "{not valid json")
+    adapter = JsonAllocationInputAdapter(file=file, allocation_type=_Request)
+
+    with pytest.raises(ValueError, match=re.escape("allocations.json")) as exc_info:
+        list(adapter.get_allocations())
+
+    assert isinstance(exc_info.value.__cause__, ValidationError)
+
+
+def test_allocation_adapter_extra_field_names_file(tmp_path: Path) -> None:
+    file = _write(
+        tmp_path,
+        "allocations.json",
+        '[{"allocation_type": "SHIFT", "totally_unknown_field": 1}]',
+    )
+    adapter = JsonAllocationInputAdapter(file=file, allocation_type=_Request)
+
+    with pytest.raises(ValueError, match=re.escape("allocations.json")) as exc_info:
+        list(adapter.get_allocations())
+
+    assert isinstance(exc_info.value.__cause__, ValidationError)


### PR DESCRIPTION
Fixes #26

## Problem
`JsonEntityInputAdapter` and `JsonAllocationInputAdapter` let `pydantic.ValidationError` propagate unwrapped, so when `CompositeInputAdapter` composes two files, a validation failure gives no indication of which file caused it.

## Fix
Wrap `pydantic.ValidationError` in `JsonEntityInputAdapter` and `JsonAllocationInputAdapter` with a `ValueError` that names `self.file`, chaining the original error via `from exc`. This makes validation failures traceable to the offending file when multiple adapters are composed (e.g. via `CompositeInputAdapter`).

## Testing
Added `tests/test_json_input_adapters.py` covering:
- Malformed JSON (both adapters) — file path appears in the error
- Extra-field schema violation (both adapters) — file path appears in the error
- Valid file — behavior unchanged

All 140 existing tests still pass. `ruff check` and `mypy src` are clean on the changed files.